### PR TITLE
feat: Add 콴다 to RSS crawler

### DIFF
--- a/scripts/rss-crawler.js
+++ b/scripts/rss-crawler.js
@@ -116,7 +116,11 @@ const RSS_FEEDS = [
     type: "company",
   },
   { name: "직방", url: "https://medium.com/feed/zigbang", type: "company" },
-
+  {
+    name: "콴다",
+    url: "https://medium.com/feed/mathpresso/tagged/frontend",
+    type: "company",
+  },
   // 개인 블로그
   {
     name: "문동욱",


### PR DESCRIPTION
## 🆕 새로운 블로그 추가

### 📋 블로그 정보

- **블로그명**: 콴다 기술블로그
- **블로그 URL**: https://blog.mathpresso.com/
- **RSS 피드 URL**: https://medium.com/feed/mathpresso/tagged/frontend
- **블로그 타입**:
  - [x] `company` (기업 블로그)
  - [ ] `personal` (개인 블로그)

### 🔍 검증 완료

- [ ] RSS 피드가 정상 작동합니다
- [ ] 블로그 타입이 올바르게 설정되었습니다
- [ ] 중복된 블로그가 아닙니다

### 📝 추가된 코드

```javascript
// scripts/rss-crawler.js에 추가
{
  name: "[블로그명]",
  url: "[RSS_URL]",
  type: "[company|personal]"
},
```

---

**PR 제출 후 GitHub Actions가 자동으로 RSS 피드 유효성을 검사합니다.**
