### PR TITLE
feat: 주간 인기글 사이드바 추가 및 기능 개선

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -41,6 +41,17 @@ export function Header({
 
           {/* 필터들 */}
           <div className="flex items-center gap-3">
+            {hasActiveFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClearFilters}
+                className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
+              >
+                <RotateCcw className="h-4 w-4 mr-1" />
+                <span>초기화</span>
+              </Button>
+            )}
             <BlogTypeToggle
               blogType={blogType}
               onBlogTypeChange={onBlogTypeChange}
@@ -50,18 +61,6 @@ export function Header({
               onBlogChange={onBlogChange}
               blogType={blogType}
             />
-
-            {hasActiveFilters && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onClearFilters}
-                className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 rounded-full bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
-              >
-                <RotateCcw className="h-4 w-4" />
-              </Button>
-            )}
-
             <ThemeToggle />
           </div>
         </div>
@@ -83,6 +82,17 @@ export function Header({
 
           {/* 두 번째 줄: 필터들 */}
           <div className="flex items-center justify-between gap-2">
+            {hasActiveFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClearFilters}
+                className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
+              >
+                <RotateCcw className="h-4 w-4" />
+                <span className="sr-only">초기화</span>
+              </Button>
+            )}
             <BlogTypeToggle
               blogType={blogType}
               onBlogTypeChange={onBlogTypeChange}
@@ -92,17 +102,6 @@ export function Header({
               onBlogChange={onBlogChange}
               blogType={blogType}
             />
-
-            {hasActiveFilters && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onClearFilters}
-                className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 rounded-full bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
-              >
-                <RotateCcw className="h-4 w-4" />
-              </Button>
-            )}
           </div>
         </div>
       </div>

--- a/components/main-content.tsx
+++ b/components/main-content.tsx
@@ -4,6 +4,7 @@ import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
 import { ViewToggle } from "@/components/view-toggle";
 import { Button } from "@/components/ui/button";
 import type { Blog } from "@/lib/supabase";
+import { ChevronLeft } from "lucide-react";
 
 interface MainContentProps {
   blogs: Blog[];
@@ -14,10 +15,12 @@ interface MainContentProps {
   viewMode: "gallery" | "list";
   searchQuery: string;
   hasActiveFilters: boolean;
+  isWeeklyExpanded: boolean;
   onLoadMore?: () => void;
   onViewModeChange: (mode: "gallery" | "list") => void;
   onSearchChange: (query: string) => void;
   onClearFilters: () => void;
+  onWeeklyToggle: () => void;
 }
 
 export function MainContent({
@@ -29,27 +32,44 @@ export function MainContent({
   viewMode,
   searchQuery,
   hasActiveFilters,
+  isWeeklyExpanded,
   onLoadMore,
   onViewModeChange,
   onSearchChange,
   onClearFilters,
+  onWeeklyToggle,
 }: MainContentProps) {
   return (
-    <main className="container mx-auto px-4 pt-4 flex-1">
+    <main className="flex-1 pt-4">
       {loading ? (
         <>
           {/* 뷰 토글 */}
-          <div className="mb-4">
+          <div className="mb-4 flex items-center gap-4">
             <ViewToggle
               viewMode={viewMode}
               onViewModeChange={onViewModeChange}
               searchQuery={searchQuery}
               onSearchChange={onSearchChange}
             />
+            {!isWeeklyExpanded && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onWeeklyToggle}
+                className="hidden xl:flex items-center gap-2 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                주간 인기글 보기
+              </Button>
+            )}
           </div>
           {/* 로딩 스켈레톤 */}
           {viewMode === "gallery" ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div
+              className={`grid grid-cols-1 md:grid-cols-2 ${
+                isWeeklyExpanded ? "xl:grid-cols-2" : "xl:grid-cols-3"
+              } gap-8`}
+            >
               {Array.from({ length: 6 }).map((_, i) => (
                 <div key={i} className="animate-pulse">
                   <div className="bg-gradient-to-br from-slate-100 to-slate-200 dark:from-slate-800 dark:to-slate-700 rounded-2xl h-80"></div>
@@ -90,13 +110,24 @@ export function MainContent({
       ) : (
         <>
           {/* 뷰 토글 */}
-          <div className="mb-4">
+          <div className="mb-4 flex items-center gap-4">
             <ViewToggle
               viewMode={viewMode}
               onViewModeChange={onViewModeChange}
               searchQuery={searchQuery}
               onSearchChange={onSearchChange}
             />
+            {!isWeeklyExpanded && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onWeeklyToggle}
+                className="hidden xl:flex items-center gap-2 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                주간 인기글 보기
+              </Button>
+            )}
           </div>
           {/* 검색 결과 개수 표시 */}
           {searchQuery && (
@@ -113,7 +144,11 @@ export function MainContent({
           )}
           {/* 블로그 목록 */}
           {viewMode === "gallery" ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div
+              className={`grid grid-cols-1 md:grid-cols-2 ${
+                isWeeklyExpanded ? "xl:grid-cols-2" : "xl:grid-cols-3"
+              } gap-8`}
+            >
               {blogs.map((blog) => (
                 <BlogCard key={blog.id} blog={blog} />
               ))}

--- a/components/weekly-popular.tsx
+++ b/components/weekly-popular.tsx
@@ -1,0 +1,107 @@
+import { Blog } from "@/lib/supabase";
+import Link from "next/link";
+import Image from "next/image";
+import { getLogoUrl } from "@/lib/logos";
+import { Eye } from "lucide-react";
+
+interface WeeklyPopularProps {
+  blogs: Blog[];
+}
+
+// 숫자 포맷팅 함수
+function formatNumber(num: number): string {
+  if (num >= 1000000) {
+    return (num / 1000000).toFixed(1) + "M";
+  }
+  if (num >= 1000) {
+    return (num / 1000).toFixed(1) + "K";
+  }
+  return num.toString();
+}
+
+// 등수별 스타일
+const rankStyles: { [key: number]: string } = {
+  1: "text-yellow-500 dark:text-yellow-400",
+  2: "text-slate-400 dark:text-slate-300",
+  3: "text-amber-600 dark:text-amber-500",
+  4: "text-slate-600 dark:text-slate-400",
+  5: "text-slate-600 dark:text-slate-400",
+  6: "text-slate-600 dark:text-slate-400",
+  7: "text-slate-600 dark:text-slate-400",
+  8: "text-slate-600 dark:text-slate-400",
+  9: "text-slate-600 dark:text-slate-400",
+  10: "text-slate-600 dark:text-slate-400",
+};
+
+export function WeeklyPopular({ blogs }: WeeklyPopularProps) {
+  return (
+    <div className="hidden xl:block w-96 flex-shrink-0">
+      <div className="sticky top-24">
+        <h2 className="text-lg font-bold mb-4 text-slate-900 dark:text-slate-100">
+          주간 인기글 TOP 10
+        </h2>
+        <div className="space-y-3">
+          {blogs.map((blog, index) => (
+            <Link
+              key={blog.id}
+              href={blog.external_url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <div className="group hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors p-4 -mx-4">
+                <div className="flex items-start gap-4">
+                  {/* 등수 */}
+                  <div
+                    className={`text-2xl font-bold ${
+                      rankStyles[(index + 1) as keyof typeof rankStyles]
+                    }`}
+                  >
+                    {index + 1}
+                  </div>
+                  {/* 블로그 로고 */}
+                  <div className="flex-shrink-0">
+                    <div className="w-10 h-10 rounded-full overflow-hidden bg-slate-100 dark:bg-slate-800">
+                      {getLogoUrl(blog.author) ? (
+                        <Image
+                          src={getLogoUrl(blog.author)!}
+                          alt={blog.author}
+                          width={40}
+                          height={40}
+                        />
+                      ) : (
+                        <Image
+                          src={
+                            blog.blog_type === "personal"
+                              ? "/placeholder-user.jpg"
+                              : "/placeholder-logo.svg"
+                          }
+                          alt={blog.author}
+                          width={40}
+                          height={40}
+                        />
+                      )}
+                    </div>
+                  </div>
+                  {/* 블로그 정보 */}
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 line-clamp-2 mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                      {blog.title}
+                    </h3>
+                    <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <span>{blog.author}</span>
+                      <span>·</span>
+                      <div className="flex items-center gap-1">
+                        <Eye className="w-3.5 h-3.5" />
+                        <span>{formatNumber(blog.views)}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -236,3 +236,22 @@ export async function incrementViews(id: number) {
     console.error("조회수 증가 실패:", error.message);
   }
 }
+
+// 주간 인기글 조회
+export async function fetchWeeklyPopularBlogs(limit = 5) {
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+  const { data, error } = await supabase
+    .from("blogs")
+    .select("*")
+    .gte("published_at", oneWeekAgo.toISOString())
+    .order("views", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`주간 인기글 조회 실패: ${error.message}`);
+  }
+
+  return data as Blog[];
+}


### PR DESCRIPTION
## 주요 변경 내용

데스크톱 사용자를 위해 화면 오른쪽에 '주간 인기글'을 보여주는 사이드바를 추가하고 관련 기능을 개선했습니다.

### 1. 주간 인기글 사이드바 구현 (TOP 10)
- 최근 7일간 조회수가 가장 높은 상위 10개의 블로그를 표시합니다.
- 금/은/동메달 색상으로 1-3위 순위를 시각적으로 강조했습니다.
- 조회수는 가독성을 위해 K, M 단위로 포맷팅하여 아이콘과 함께 보여줍니다.

### 2. 사이드바 토글 기능 및 동적 레이아웃
- 사용자가 사이드바를 열고 닫을 수 있는 토글 기능을 추가했습니다.
- 닫기: 메인 콘텐츠와 사이드바 사이의 구분선에 있는 버튼(>)을 클릭하여 닫을 수 있습니다.
- 열기: 메인 콘텐츠 상단의 '주간 인기글 보기' 버튼으로 다시 열 수 있습니다.
- 사이드바 상태에 따라 메인 콘텐츠의 갤러리 뷰가 2열 ↔ 3열로 동적으로 변경되어 화면 공간을 효율적으로 사용합니다.

### 3. UI/UX 개선
- 로고가 없는 개인 블로그의 경우, 기본 로고 대신 사용자 아이콘이 표시되도록 하여 시각적 구분을 명확히 했습니다.
- 전체적인 레이아웃, 간격, 호버 효과 등을 다듬어 사용자 경험을 개선했습니다.


## 🤔 추가 논의 및 고민 사항
1. 기본 뷰(View) 모드 설정: 목록 vs 갤러리
현재: '갤러리 뷰'가 기본으로 설정되어 있지만, 주간 인기글 영역이 추가되면서 갤러리 뷰 글이 2x2로 적게 보임
고민: '목록 뷰'를 기본값으로 변경할지 고민중

2. 모바일 환경에서의 '주간 인기글' 구현 방안
현재: 모바일 화면에서는 주간 인기글 기능이 보이지 않음 
고민: 모바일에서도 이 기능을 어떻게 제공할지 고민중

## 스크린샷
![image](https://github.com/user-attachments/assets/5b14f5d1-a04f-40a8-b477-60cdb32f2b62)
![image](https://github.com/user-attachments/assets/07407786-c24d-48c2-bfbe-65bec3c1c15d)
