### PR TITLE
feat: Discord 웹훅으로 새 기술블로그 글 알림 전송

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # 배포 환경
 NODE_ENV=development
 
+# Discord 웹훅 알림 (선택)
+DISCORD_WEBHOOK_URL=your_discord_webhook_url
+
 # Fireworks AI (태그 생성)
 FIREWORKS_API_KEY=your_fireworks_api_key
 # 기본 모델 (예: accounts/fireworks/models/deepseek-v3p1-terminus)

--- a/.github/workflows/rss-crawler.yml
+++ b/.github/workflows/rss-crawler.yml
@@ -46,6 +46,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           NODE_OPTIONS: "--max-old-space-size=4096"
 
       - name: Upload crawl results

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 ### 🤖 자동 데이터 수집
 
-- RSS 피드 자동 크롤링
+- RSS 피드 자동 크롤링 (하루 2회: 오전 7시, 오후 7시 KST)
+- 새 글 발견 시 Discord 웹훅 알림
 
 ## 🛠 기술 스택
 
@@ -60,6 +61,7 @@ cp .env.example .env.local
    NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
    SUPABASE_SERVICE_ROLE_KEY=your_service_role_key  # RSS 크롤러용
+   DISCORD_WEBHOOK_URL=your_discord_webhook_url    # Discord 알림용 (선택)
    ```
 
 3. 데이터베이스 스키마 생성:

--- a/scripts/discord-webhook.js
+++ b/scripts/discord-webhook.js
@@ -1,0 +1,71 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+
+/**
+ * Discord 웹훅으로 새 기술블로그 글 알림 전송
+ * @param {Array} newArticles - 새로 크롤링된 글 목록
+ */
+export async function sendDiscordNotification(newArticles) {
+  if (!DISCORD_WEBHOOK_URL) {
+    console.log("⚠️  DISCORD_WEBHOOK_URL이 설정되지 않았습니다. Discord 알림을 건너뜁니다.");
+    return;
+  }
+
+  if (!newArticles || newArticles.length === 0) return;
+
+  try {
+    // 블로그별로 그룹화
+    const grouped = {};
+    for (const article of newArticles) {
+      const author = article.author || "기타";
+      if (!grouped[author]) grouped[author] = [];
+      grouped[author].push(article);
+    }
+
+    // Embed 필드 생성 (블로그별 새 글 목록)
+    const fields = Object.entries(grouped).map(([author, articles]) => ({
+      name: `📝 ${author} (${articles.length}개)`,
+      value: articles
+        .slice(0, 5) // 블로그당 최대 5개
+        .map((a) => `[${truncate(a.title, 50)}](${a.external_url})`)
+        .join("\n"),
+      inline: false,
+    }));
+
+    // Discord embed 메시지 (최대 25개 필드 제한)
+    const embeds = [];
+    for (let i = 0; i < fields.length; i += 25) {
+      embeds.push({
+        title: i === 0 ? `🚀 새 기술블로그 글 ${newArticles.length}개 업데이트!` : null,
+        color: 0x5865f2, // Discord 블루
+        fields: fields.slice(i, i + 25),
+        ...(i === 0 && {
+          footer: { text: "techgom RSS Crawler" },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    }
+
+    const response = await fetch(DISCORD_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ embeds }),
+    });
+
+    if (response.ok) {
+      console.log(`✅ Discord 알림 전송 완료 (${newArticles.length}개 글)`);
+    } else {
+      const text = await response.text();
+      console.error(`❌ Discord 알림 전송 실패: ${response.status} ${text}`);
+    }
+  } catch (error) {
+    console.error("❌ Discord 알림 전송 중 오류:", error.message);
+  }
+}
+
+function truncate(str, maxLength) {
+  if (!str) return "제목 없음";
+  return str.length > maxLength ? str.slice(0, maxLength) + "..." : str;
+}

--- a/scripts/rss-crawler.js
+++ b/scripts/rss-crawler.js
@@ -66,11 +66,11 @@ const RSS_FEEDS = [
     url: "https://techblog.lycorp.co.jp/ko/feed/index.xml",
     type: "company",
   },
-  {
-    name: "마켓컬리",
-    url: "https://helloworld.kurly.com/feed.xml",
-    type: "company",
-  },
+  // {
+  //   name: "마켓컬리",
+  //   url: "https://helloworld.kurly.com/feed.xml",
+  //   type: "company",
+  // }, // RSS 피드 403 차단
   {
     name: "에잇퍼센트",
     url: "https://8percent.github.io/feed.xml",

--- a/scripts/rss-crawler.js
+++ b/scripts/rss-crawler.js
@@ -7,6 +7,7 @@ import {
   sendBatchNotifications,
 } from "./push-notification.js";
 import { generateTagsForArticle, baseTagsFromFeedCategory } from "./ai-tags.js";
+import { sendDiscordNotification } from "./discord-webhook.js";
 
 /**
  * RSS 피드 크롤러 (중복 방지 개선 버전)
@@ -822,6 +823,9 @@ async function main() {
     if (allNewArticles.length > 0) {
       console.log("\n📱 푸시 알림 처리 중...");
       await sendBatchNotifications(allNewArticles);
+
+      // 🔔 Discord 웹훅 알림
+      await sendDiscordNotification(allNewArticles);
     }
   } catch (error) {
     console.error("❌ 크롤링 중 치명적 오류:", error.message);

--- a/scripts/validate-rss.js
+++ b/scripts/validate-rss.js
@@ -31,7 +31,7 @@ function extractRssUrls() {
 
     const feedsContent = rssFeedsMatch[1];
     const urlMatches = Array.from(
-      feedsContent.matchAll(/^\s*(?!\/\/).*url:\s*["']([^"']+)["']/gm)
+      feedsContent.matchAll(/^(?!\s*\/\/).*url:\s*["']([^"']+)["']/gm)
     );
 
     if (!urlMatches || urlMatches.length === 0) {


### PR DESCRIPTION
## Summary
- RSS 크롤링 완료 후 새 글이 있으면 Discord 웹훅으로 알림 전송
- 블로그별 그룹화된 embed 메시지로 가독성 확보
- README에 Discord 알림 및 크롤링 주기 안내 추가

## 변경 파일
- `scripts/discord-webhook.js` — Discord 웹훅 알림 모듈 (신규)
- `scripts/rss-crawler.js` — 크롤링 후 Discord 알림 호출 추가
- `.github/workflows/rss-crawler.yml` — `DISCORD_WEBHOOK_URL` 환경변수 추가
- `README.md` — 자동 데이터 수집 섹션 업데이트

## 설정
- GitHub Secrets에 `DISCORD_WEBHOOK_URL` 추가 필요

## 스크린샷
<img width="425" height="451" alt="image" src="https://github.com/user-attachments/assets/8da95615-2c90-452b-ad7b-edb567500820" /> 

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * RSS 피드에서 새 글이 발견될 때 Discord 웹훅을 통한 자동 알림 기능 추가
  * 저자별로 그룹화하여 Discord 임베드 형식의 상세한 알림 정보 전달

* **문서**
  * RSS 자동 크롤링 일정(매일 오전 7시, 오후 7시 KST) 및 Discord 알림 기능 설명 추가
  * 환경 변수 설정 가이드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->